### PR TITLE
Add operators for dropdowns. Support unique values

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "QueryBuilder",
-    "version": "1.7.0",
+    "version": "1.7.1",
     "description": "Query Builder",
     "author": "PTC + IQNOX",
     "minimumThingWorxVersion": "6.0.0",


### PR DESCRIPTION
## Intent

- add proper support for `useRowAsValues` when each row has multiple, non-unique value.
- support case when some rows don't have values and should still use textboxes.

## Implementation

- for each row, get the unique values. If there's more than 0, then use a dropdown with those values
- otherwise, use a textbox.